### PR TITLE
Fan Presence and Fail GPIO reads in FanSensor plus sensors thermal update for PID algorithms

### DIFF
--- a/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
+++ b/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
@@ -432,7 +432,7 @@
         "PinName": "FAN7_FAIL",
         "Polarity": "High",
         "MonitorType": "Polling"
-      },
+      }
     },
     {
       "Name": "Fan 4",
@@ -470,7 +470,7 @@
         "PinName": "FAN11_FAIL",
         "Polarity": "High",
         "MonitorType": "Polling"
-      },
+      }
     },
     {
       "Name": "Fan 6",
@@ -489,7 +489,7 @@
         "PinName": "FAN13_FAIL",
         "Polarity": "High",
         "MonitorType": "Polling"
-      },
+      }
     },
     {
       "Name": "Zone 1",
@@ -783,7 +783,7 @@
       "_comment1": "Experimental FanAlg work",
       "Class": "temp",
       "Name": "DIMMs FanAlg",
-      "Inputs": [ "CPU\d+_DIMM_[a-zA-Z]\d+" ],
+      "Inputs": [ "CPU\\d+_DIMM_[a-zA-Z]\\d+" ],
       "Outputs": [],
 
       "SetPoint": 76,

--- a/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
+++ b/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
@@ -383,7 +383,8 @@
       "Connector": {
         "_comment1": "on the Dl340, fans reads start from 'hwmon/pwm2' so start fan 1 numbering from pwm=1, and index=1 instead of the usual 0-based",
         "Name": "Fan Conn 1",
-        "Pwm": 1
+        "Pwm": 1,
+        "PwmName": "Pwm 1"
       },
       "Presence": {
         "PinName": "FAN2_INST",
@@ -402,7 +403,8 @@
       "Index": 2,
       "Connector": {
         "Name": "Fan Conn 2",
-        "Pwm": 2
+        "Pwm": 2,
+        "PwmName": "Pwm 2"
       },
       "Presence": {
         "PinName": "FAN3_INST",
@@ -416,12 +418,13 @@
       }
     },
     { 
-      "Name": "Raw Fan 3",
+      "Name": "Fan 3",
       "Type": "HPEFan",
       "Index": 3,
       "Connector": {
         "Name": "Fan Conn 3",
-        "Pwm": 3
+        "Pwm": 3,
+        "PwmName": "Pwm 3"
       },
       "Presence": {
         "PinName": "FAN4_INST",
@@ -440,7 +443,8 @@
       "Index": 4,
       "Connector": {
         "Name": "Fan Conn 4",
-        "Pwm": 4
+        "Pwm": 4,
+        "PwmName": "Pwm 4"
       },
       "Presence": {
         "PinName": "FAN5_INST",
@@ -459,7 +463,8 @@
       "Index": 5,
       "Connector": {
         "Name": "Fan Conn 5",
-        "Pwm": 5
+        "Pwm": 5,
+        "PwmName": "Pwm 5"
       },
       "Presence": {
         "PinName": "FAN6_INST",
@@ -478,7 +483,8 @@
       "Index": 6,
       "Connector": {
         "Name": "Fan Conn 6",
-        "Pwm": 6
+        "Pwm": 6,
+        "PwmName": "Pwm 6"
       },
       "Presence": {
         "PinName": "FAN8_INST",

--- a/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
+++ b/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
@@ -487,7 +487,7 @@
         "PwmName": "Pwm 6"
       },
       "Presence": {
-        "PinName": "FAN8_INST",
+        "PinName": "FAN7_INST",
         "Polarity": "High",
         "MonitorType": "Polling"
       },

--- a/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
+++ b/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
@@ -56,13 +56,13 @@
           "Direction": "greater than",
           "Name": "upper critical",
           "Severity": 1,
-          "Value": 80
+          "Value": 115
         },
         {
           "Direction": "greater than",
           "Name": "upper non critical",
           "Severity": 0,
-          "Value": 75
+          "Value": 110
         },
         {
           "Direction": "less than",
@@ -79,8 +79,8 @@
       ]
     },
     {
-      "Name": "01-Inlet Ambient",
-      "Name1": "45-Board Inlet",
+      "Name": "01 Inlet Ambient",
+      "Name1": "45 Board Inlet",
       "Type": "TMP411",
       "Bus": "47",
       "Address": "0x4c",
@@ -145,7 +145,7 @@
       ]
     },
     {
-      "Name": "23-BMC Zone",
+      "Name": "23 BMC Zone",
       "Type": "TMP1075",
       "Bus": "2",
       "Address": "0x4B",
@@ -179,7 +179,7 @@
     },
     
     {
-      "Name": "46-Battery Zone",
+      "Name": "46 Battery Zone",
       "Type": "TMP1075",
       "Bus": "48",
       "Address": "0x4A",
@@ -212,7 +212,7 @@
       ]
     },
     {
-      "Name": "47-Sys Exhaust 1",
+      "Name": "47 Sys Exhaust 1",
       "Type": "TMP1075",
       "Bus": "48",
       "Address": "0x4B",
@@ -245,7 +245,7 @@
       ]
     },
     {
-      "Name": "48-Sys Exhaust 2",
+      "Name": "48 Sys Exhaust 2",
       "Type": "TMP1075",
       "Bus": "48",
       "Address": "0x49",
@@ -375,85 +375,127 @@
         }
       ],
       "Type": "TMP1075"
-    },
+    },    
     {
+      "Name": "Fan 1",
+      "Type": "HPEFan",
+      "Index": 1,
       "Connector": {
         "_comment1": "on the Dl340, fans reads start from 'hwmon/pwm2' so start fan 1 numbering from pwm=1, and index=1 instead of the usual 0-based",
-        "Fail": "FAN3_FAIL",
-        "Inst": "FAN2_INST",
         "Name": "Fan Conn 1",
-        "Pwm": 1,
-        "PwmName": "Fan 1",
-        "Tachs": [ 1 ]
+        "Pwm": 1
       },
-      "Name": "Raw Fan 1",
-      "Type": "HPEFan",
-      "Index": 1
+      "Presence": {
+        "PinName": "FAN2_INST",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+      "Monitor": {
+        "PinName": "FAN3_FAIL",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      }
     },
-    {
+    { 
+      "Name": "Fan 2",
+      "Type": "HPEFan",
+      "Index": 2,
       "Connector": {
-        "Fail": "FAN5_FAIL",
-        "Inst": "FAN3_INST",
         "Name": "Fan Conn 2",
-        "Pwm": 2,
-        "PwmName": "Fan 2",
-        "Tachs": [ 2 ]
+        "Pwm": 2
       },
-      "Name": "Raw Fan 2",
-      "Type": "HPEFan",
-      "Index": 2
+      "Presence": {
+        "PinName": "FAN3_INST",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+      "Monitor": {
+        "PinName": "FAN5_FAIL",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      }
     },
-    {
-      "Connector": {
-        "Fail": "FAN7_FAIL",
-        "Inst": "FAN4_INST",
-        "Name": "Fan Conn 3",
-        "Pwm": 3,
-        "PwmName": "Fan 3",
-        "Tachs": [ 3 ]
-      },
+    { 
       "Name": "Raw Fan 3",
       "Type": "HPEFan",
-      "Index": 3
+      "Index": 3,
+      "Connector": {
+        "Name": "Fan Conn 3",
+        "Pwm": 3
+      },
+      "Presence": {
+        "PinName": "FAN4_INST",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+      "Monitor": {
+        "PinName": "FAN7_FAIL",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
     },
     {
+      "Name": "Fan 4",
+      "Type": "HPEFan",
+      "Index": 4,
       "Connector": {
-        "Fail": "FAN9_FAIL",
-        "Inst": "FAN5_INST",
         "Name": "Fan Conn 4",
-        "Pwm": 4,
-        "PwmName": "Fan 4",
-        "Tachs": [ 4 ]
+        "Pwm": 4
       },
-      "Name": "Raw Fan 4",
-      "Type": "HPEFan",
-      "Index": 4
+      "Presence": {
+        "PinName": "FAN5_INST",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+      "Monitor": {
+        "PinName": "FAN9_FAIL",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      }
     },
     {
+      "Name": "Fan 5",
+      "Type": "HPEFan",
+      "Index": 5,
       "Connector": {
-        "Fail": "FAN11_FAIL",
-        "Inst": "FAN6_INST",
         "Name": "Fan Conn 5",
-        "Pwm": 5,
-        "PwmName": "Fan 5",
-        "Tachs": [ 5 ]
+        "Pwm": 5
       },
-      "Name": "Raw Fan 5",
-      "Type": "HPEFan",
-      "Index": 5
+      "Presence": {
+        "PinName": "FAN6_INST",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+      "Monitor": {
+        "PinName": "FAN11_FAIL",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
     },
     {
-      "Connector": {
-        "Fail": "FAN13_FAIL",
-        "Inst": "FAN8_INST",
-        "Name": "Fan Conn 6",
-        "Pwm": 6,
-        "PwmName": "Fan 6",
-        "Tachs": [ 6 ]
-      },
-      "Name": "Raw Fan 6",
+      "Name": "Fan 6",
       "Type": "HPEFan",
-      "Index": 6
+      "Index": 6,
+      "Connector": {
+        "Name": "Fan Conn 6",
+        "Pwm": 6
+      },
+      "Presence": {
+        "PinName": "FAN8_INST",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+      "Monitor": {
+        "PinName": "FAN13_FAIL",
+        "Polarity": "High",
+        "MonitorType": "Polling"
+      },
+    },
+    {
+      "Name": "Zone 1",
+      "Type": "Pid.Zone",
+      "FailSafePercent": 100,
+      "MinThermalOutput": 10
     },
     {
       "Class": "fan",
@@ -463,24 +505,24 @@
       "ILimitMax": 0,
       "ILimitMin": 0,
       "Inputs": [
-        "Raw Fan 1",
-        "Raw Fan 2",
-        "Raw Fan 3",
-        "Raw Fan 4",
-        "Raw Fan 5",
-        "Raw Fan 6"
-      ],
-      "Name": "Fan 1-6",
-      "NegativeHysteresis": 0,
-      "OutLimitMax": 100,
-      "OutLimitMin": 30,
-      "Outputs": [
         "Fan 1",
         "Fan 2",
         "Fan 3",
         "Fan 4",
         "Fan 5",
         "Fan 6"
+      ],
+      "Name": "Fan 1-6",
+      "NegativeHysteresis": 0,
+      "OutLimitMax": 100,
+      "OutLimitMin": 30,
+      "Outputs": [
+        "Pwm 1",
+        "Pwm 2",
+        "Pwm 3",
+        "Pwm 4",
+        "Pwm 5",
+        "Pwm 6"
       ],
       "PCoefficient": 0,
       "PositiveHysteresis": 0,
@@ -499,7 +541,7 @@
       "ILimitMax": 100,
       "ILimitMin": 30,
       "Inputs": [
-        "DTS CPU1"
+        "DTS CPU 1"
       ],
       "Name": "DTS CPU1 Zn",
       "NegativeHysteresis": 5,
@@ -518,22 +560,64 @@
       ]
     },
     {
+      "_comment1": "Experimental FanAlg work below",
       "Class": "temp",
+      "Inputs": [
+        "01 Inlet Ambient"
+      ],
+      "Name": "01 Inlet Ambient FanAlg",
+      "NegativeHysteresis": 0,
+      "Reading": [
+                15.0,
+                20.0,
+                25.0,
+                30.0,
+                37.0,
+                40.0,
+                45.0
+      ],
+      "_comment2": "Converted output from duty cycle x/255 to perccentage",
+      "Output": [
+                12.0,
+                12.0,
+                12.0,
+                12.0,
+                12.0,
+                39.0,
+                59.0
+      ],
+      "PositiveHysteresis": 0,
+      
+      "Type": "Stepwise",
+      "Zones": [
+                "Zone 1"
+      ]
+    },
+    {
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "GSC Temp FanAlg",
+      "Inputs": [ "GSC Temp" ],
+      "Outputs": [],
+
+      "SetPoint": 95,
+      "PCoefficient": -5,
+      "ICoefficient": -0.15,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 0,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
       "FFGainCoefficient": 0,
       "FFOffCoefficient": 0,
-      "ICoefficient": -0.2,
-      "ILimitMax": 70,
-      "ILimitMin": 10,
-      "Inputs": [
-        "Front Inlet"
-      ],
-      "Name": "Ambient Temp Zn",
-      "OutLimitMax": 70,
-      "OutLimitMin": 10,
-      "Outputs": [],
-      "PCoefficient": -3,
-      "SetPoint": 25,
-      "SlewNeg": -1,
+      
+      "NegativeHysteresis": 3.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
       "SlewPos": 0,
       "Type": "Pid",
       "Zones": [
@@ -541,10 +625,190 @@
       ]
     },
     {
-      "FailSafePercent": 100,
-      "MinThermalOutput": 10,
-      "Name": "Zone 1",
-      "Type": "Pid.Zone"
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "23 BMC Zone FanAlg",
+      "Inputs": [ "23 BMC Zone" ],
+      "Outputs": [],
+
+      "SetPoint": 60,
+      "PCoefficient": -5,
+      "ICoefficient": -0.15,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 12,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
+      "FFGainCoefficient": 0,
+      "FFOffCoefficient": 0,
+      
+      "NegativeHysteresis": 0.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
+      "SlewPos": 0,
+      "Type": "Pid",
+      "Zones": [
+        "Zone 1"
+      ]
+    },
+    {
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "46 Battery Zone FanAlg",
+      "Inputs": [ "46 Battery Zone" ],
+      "Outputs": [],
+
+      "SetPoint": 65,
+      "PCoefficient":-5,
+      "ICoefficient": -0.15,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 0,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
+      "FFGainCoefficient": 0,
+      "FFOffCoefficient": 0,
+      
+      "NegativeHysteresis": 0.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
+      "SlewPos": 0,
+      "Type": "Pid",
+      "Zones": [
+        "Zone 1"
+      ]
+    },
+    {
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "47 Sys Exhaust 1 FanAlg",
+      "Inputs": [ "47 Sys Exhaust 1" ],
+      "Outputs": [],
+
+      "SetPoint": 65,
+      "PCoefficient": -5,
+      "ICoefficient": -0.15,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 0,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
+      "FFGainCoefficient": 0,
+      "FFOffCoefficient": 0,
+      
+      "NegativeHysteresis": 0.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
+      "SlewPos": 0,
+      "Type": "Pid",
+      "Zones": [
+        "Zone 1"
+      ]
+    },
+    {
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "48 Sys Exhaust 2 FanAlg",
+      "Inputs": [ "48 Sys Exhaust 2" ],
+      "Outputs": [],
+
+      "SetPoint": 55,
+      "PCoefficient": -5,
+      "ICoefficient": -0.15,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 0,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
+      "FFGainCoefficient": 0,
+      "FFOffCoefficient": 0,
+      
+      "NegativeHysteresis": 0.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
+      "SlewPos": 0,
+      "Type": "Pid",
+      "Zones": [
+        "Zone 1"
+      ]
+    },
+    {
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "PSU @ 1U PDB Temp FanAlg",
+      "Inputs": [ "PSU @ 1U PDB Temp" ],
+      "Outputs": [],
+
+      "SetPoint": 60,
+      "PCoefficient": -5,
+      "ICoefficient": -0.15,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 0,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
+      "FFGainCoefficient": 0,
+      "FFOffCoefficient": 0,
+      
+      "NegativeHysteresis": 0.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
+      "SlewPos": 0,
+      "Type": "Pid",
+      "Zones": [
+        "Zone 1"
+      ]
+    },
+    {
+      "_comment1": "Experimental FanAlg work",
+      "Class": "temp",
+      "Name": "DIMMs FanAlg",
+      "Inputs": [ "CPU\d+_DIMM_[a-zA-Z]\d+" ],
+      "Outputs": [],
+
+      "SetPoint": 76,
+      "PCoefficient": -5,
+      "ICoefficient": -0.5,
+      "DCoefficient": 0,
+
+      "OutLimitMin": 0,
+      "OutLimitMax": 100,
+      
+      "ILimitMin": 12,
+      "ILimitMax": 100,
+
+      "FFGainCoefficient": 0,
+      "FFOffCoefficient": 0,
+      
+      "NegativeHysteresis": 0.0,
+      "PositiveHysteresis": 0,
+      
+      "SlewNeg": 0,
+      "SlewPos": 0,
+      "Type": "Pid",
+      "Zones": [
+        "Zone 1"
+      ]
     }
   ],
   "Name": "DL340 G12 Server",

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0001-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0001-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch
@@ -1,0 +1,393 @@
+From 5e55c26fe657d04ef6714d922f01a3080df66740 Mon Sep 17 00:00:00 2001
+From: Chris Sides <Christopher.Sides@hpe.com>
+Date: Mon, 14 Jul 2025 15:41:03 -0500
+Subject: [PATCH] now supports gpio based fail bit monitoring as well as
+ presence detection. Also workaround for issue where swampd incorrectly marked
+ 'not present' sensors as 'failed' and goes to failsale speed w/o checking
+ redundancy rules or fan status on dbus first
+
+---
+ src/fan/FanMain.cpp    | 155 ++++++++++++++++++++++++++++++++++++-----
+ src/fan/TachSensor.cpp |  48 ++++++++++++-
+ src/fan/TachSensor.hpp |   2 +
+ 3 files changed, 185 insertions(+), 20 deletions(-)
+
+diff --git a/src/fan/FanMain.cpp b/src/fan/FanMain.cpp
+index f210f7f..4cd5a61 100644
+--- a/src/fan/FanMain.cpp
++++ b/src/fan/FanMain.cpp
+@@ -198,14 +198,32 @@ bool findPwmPath(const std::filesystem::path& directory, unsigned int pwm,
+     return true;
+ }
+ 
+-// The argument to this function should be the fanN_input file that we want to
+-// enable. The function will locate the corresponding fanN_enable file if it
+-// exists. Note that some drivers don't provide this file if the sensors are
+-// always enabled.
+-void enableFanInput(const std::filesystem::path& fanInputPath)
++//takes a hwmon pwm (output) handle as a parameter
++//returns 'fanN_input' hwmon path if it exists, otherwise returns the original path 'pwmN'
++//to allow for controlling fans with no acessible tachometer
++std::filesystem::path getFanInputPath(const std::filesystem::path& fanOutputPath)
++{
++    std::string path(fanOutputPath.string());
++    boost::replace_last(path, "pwm", "fan"); //look for fanN_input
++    path+="_input";
++    std::filesystem::path fanInputPath(path);
++
++    if (std::filesystem::exists(fanInputPath))
++    {
++        return fanInputPath;
++    }
++
++    return fanOutputPath; 
++}
++
++// The argument to this function should be the 'pwmN' file associated with the 
++// fanN_input that we want to enable. The function will locate the
++// corresponding fanN_enable file if it exists. Note that some drivers don't
++// provide this file if the sensors are always enabled.
++void enableFanInput(const std::filesystem::path& fanOutputPath)
+ {
+     std::error_code ec;
+-    std::string path(fanInputPath.string());
++    std::string path(fanOutputPath.string());
+     boost::replace_last(path, "pwm", "fan");
+     path+="_enable";
+ 
+@@ -280,6 +298,8 @@ void createSensors(
+         pwmSensors,
+     boost::container::flat_map<std::string, std::weak_ptr<PresenceGpio>>&
+         presenceGpios,
++    boost::container::flat_map<std::string, std::weak_ptr<PresenceGpio>>&
++        monitorGpios,
+     std::shared_ptr<sdbusplus::asio::connection>& dbusConnection,
+     const std::shared_ptr<boost::container::flat_set<std::string>>&
+         sensorsChanged,
+@@ -289,30 +309,31 @@ void createSensors(
+         GetSensorConfiguration>(dbusConnection, [&io, &objectServer,
+                                                  &tachSensors, &pwmSensors,
+                                                  &presenceGpios,
++                                                 &monitorGpios,
+                                                  &dbusConnection,
+                                                  sensorsChanged](
+                                                     const ManagedObjectType&
+                                                         sensorConfigurations) {
+         bool firstScan = sensorsChanged == nullptr;
+-        std::vector<std::filesystem::path> paths;
++        std::vector<std::filesystem::path> fanOutputPaths;
+         if (!findFiles(std::filesystem::path("/sys/class/hwmon"),
+-                       R"(pwm\d+)", paths))
++                       R"(pwm\d+)", fanOutputPaths))
+         {
+-            lg2::error("No fan sensors in system");
++            lg2::error("No fan pwm controls in system");
+             return;
+         }
+ 
+         // iterate through all found fan sensors, and try to match them with
+         // configuration
+-        for (const auto& path : paths)
++        for (const auto& fanOutputPath : fanOutputPaths)
+         {
+             std::smatch match;
+-            std::string pathStr = path.string();
++            std::string pathStr = fanOutputPath.string();
+ 
+             std::regex_search(pathStr, match, inputRegex);
+             std::string indexStr = *(match.begin() + 1);
+ 
+-            std::filesystem::path directory = path.parent_path();
++            std::filesystem::path directory = fanOutputPath.parent_path();
+             FanTypes fanType = getFanType(directory);
+             std::string cfgIntf = configInterfaceName(sensorTypes[fanType]);
+ 
+@@ -396,7 +417,7 @@ void createSensors(
+             if (sensorData == nullptr)
+             {
+                 lg2::error("failed to find match for '{PATH}'", "PATH",
+-                           path.string());
++                           fanOutputPath.string());
+                 continue;
+             }
+ 
+@@ -406,7 +427,7 @@ void createSensors(
+             {
+                 lg2::error(
+                     "could not determine configuration name for '{PATH}'",
+-                    "PATH", path.string());
++                    "PATH", fanOutputPath.string());
+                 continue;
+             }
+             std::string sensorName =
+@@ -531,6 +552,98 @@ void createSensors(
+                     }
+                 }
+             }
++
++            auto monitorConfig = 
++                sensorData->find(cfgIntf + std::string(".Monitor"));  //monitor for failures
++            
++            std::shared_ptr<PresenceGpio> monitorGpio(nullptr);
++            
++            // monitor sensors are optional
++            if (monitorConfig != sensorData->end())
++            {
++                auto findFailPolarity = monitorConfig->second.find("Polarity");
++                auto findFailPinName = monitorConfig->second.find("PinName");
++
++                if (findFailPinName == monitorConfig->second.end() ||
++                    findFailPolarity == monitorConfig->second.end())
++                {
++                    lg2::error("Malformed Monitor Configuration");
++                }
++                else
++                {
++                    bool inverted =
++                        std::get<std::string>(findFailPolarity->second) == "Low";
++                    const auto* pinName =
++                        std::get_if<std::string>(&findFailPinName->second);
++
++                    if (pinName != nullptr)
++                    {
++                        auto findmonitorGpio = monitorGpios.find(*pinName);
++                        if (findmonitorGpio != monitorGpios.end())
++                        {
++                            auto p = findmonitorGpio->second.lock();
++                            if (p)
++                            {
++                                monitorGpio = p;
++                            }
++                        }
++                        if (!monitorGpio)
++                        {
++                            auto findMonitorType =
++                                monitorConfig->second.find("MonitorType");
++                            bool polling = false;
++                            if (findMonitorType != monitorConfig->second.end())
++                            {
++                                auto mType = std::get<std::string>(
++                                    findMonitorType->second);
++                                if (mType == "Polling")
++                                {
++                                    polling = true;
++                                }
++                                else if (mType != "Event")
++                                {
++                                    lg2::error(
++                                        "Unsupported GPIO MonitorType of '{TYPE}' for '{NAME}', "
++                                        "supported types: Polling, Event default",
++                                        "TYPE", mType, "NAME", sensorName);
++                                }
++                            }
++                            try
++                            {
++                                if (polling)
++                                {
++                                    monitorGpio =
++                                        std::make_shared<PollingPresenceGpio>(
++                                            "Fan", sensorName, *pinName,
++                                            inverted, io);
++                                }
++                                else
++                                {
++                                    monitorGpio =
++                                        std::make_shared<EventPresenceGpio>(
++                                            "Fan", sensorName, *pinName,
++                                            inverted, io);
++                                }
++                                monitorGpios[*pinName] = monitorGpio;
++                            }
++                            catch (const std::system_error& e)
++                            {
++                                lg2::error(
++                                    "Failed to create GPIO monitor object for "
++                                    "'{PIN_NAME}' / '{SENSOR_NAME}': '{ERROR}'",
++                                    "PIN_NAME", *pinName, "SENSOR_NAME",
++                                    sensorName, "ERROR", e);
++                            }
++                        }
++                    }
++                    else
++                    {
++                        lg2::error(
++                            "Malformed monitor pinName for sensor '{NAME}'",
++                            "NAME", sensorName);
++                    }
++                }
++            }
+             std::optional<RedundancySensor>* redundancy = nullptr;
+             if (fanType == FanTypes::aspeed)
+             {
+@@ -624,13 +737,15 @@ void createSensors(
+ 
+             findLimits(limits, baseConfiguration);
+ 
+-            enableFanInput(path);
++            enableFanInput(fanOutputPath);
++
++            auto fanInputPath = getFanInputPath(fanOutputPath);
+ 
+             auto& tachSensor = tachSensors[sensorName];
+             tachSensor = nullptr;
+             tachSensor = std::make_shared<TachSensor>(
+-                path.string(), baseType, objectServer, dbusConnection,
+-                presenceGpio, redundancy, io, sensorName,
++                fanInputPath.string(), baseType, objectServer, dbusConnection,
++                presenceGpio, monitorGpio, redundancy, io, sensorName,
+                 std::move(sensorThresholds), *interfacePath, limits, powerState,
+                 led);
+             tachSensor->setupRead();
+@@ -667,11 +782,13 @@ int main()
+         pwmSensors;
+     boost::container::flat_map<std::string, std::weak_ptr<PresenceGpio>>
+         presenceGpios;
++    boost::container::flat_map<std::string, std::weak_ptr<PresenceGpio>>
++        monitorGpios;
+     auto sensorsChanged =
+         std::make_shared<boost::container::flat_set<std::string>>();
+ 
+     boost::asio::post(io, [&]() {
+-        createSensors(io, objectServer, tachSensors, pwmSensors, presenceGpios,
++        createSensors(io, objectServer, tachSensors, pwmSensors, presenceGpios, monitorGpios,
+                       systemBus, nullptr);
+     });
+ 
+@@ -699,7 +816,7 @@ int main()
+                     return;
+                 }
+                 createSensors(io, objectServer, tachSensors, pwmSensors,
+-                              presenceGpios, systemBus, sensorsChanged, 5);
++                              presenceGpios, monitorGpios, systemBus, sensorsChanged, 5);
+             });
+         };
+ 
+diff --git a/src/fan/TachSensor.cpp b/src/fan/TachSensor.cpp
+index c8a3c40..258d9e7 100644
+--- a/src/fan/TachSensor.cpp
++++ b/src/fan/TachSensor.cpp
+@@ -48,6 +48,7 @@ TachSensor::TachSensor(
+     sdbusplus::asio::object_server& objectServer,
+     std::shared_ptr<sdbusplus::asio::connection>& conn,
+     std::shared_ptr<PresenceGpio>& presenceGpio,
++    std::shared_ptr<PresenceGpio>& monitorGpio,
+     std::optional<RedundancySensor>* redundancy, boost::asio::io_context& io,
+     const std::string& fanName,
+     std::vector<thresholds::Threshold>&& thresholdsIn,
+@@ -58,6 +59,7 @@ TachSensor::TachSensor(
+            objectType, false, false, limits.second, limits.first, conn,
+            powerState),
+     objServer(objectServer), redundancy(redundancy), presence(presenceGpio),
++    monitor(monitorGpio),
+     inputDev(io, path, boost::asio::random_access_file::read_only),
+     waitTimer(io), path(path), led(ledIn)
+ {
+@@ -85,6 +87,10 @@ TachSensor::TachSensor(
+         itemIface->register_property("PrettyName",
+                                      std::string()); // unused property
+         itemIface->register_property("Present", true);
++
++        if (monitor) 
++           itemIface->register_property("Functional", true);
++
+         itemIface->initialize();
+         itemAssoc = objectServer.add_interface(
+             "/xyz/openbmc_project/inventory/" + name, association::interface);
+@@ -95,6 +101,12 @@ TachSensor::TachSensor(
+                  "/xyz/openbmc_project/sensors/fan_tach/" + name}});
+         itemAssoc->initialize();
+     }
++
++    if (monitor) 
++    {
++        monitor->monitorPresence(); //kick off monitoring (polling) for the monitor/fail bit or handle        
++    }
++    
+     setInitialProperties(sensor_paths::unitRPMs);
+ }
+ 
+@@ -156,6 +168,7 @@ void TachSensor::handleResponse(const boost::system::error_code& err,
+         return; // we're being destroyed
+     }
+     bool missing = false;
++    bool failed = false;
+     size_t pollTime = pwmPollMs;
+     if (presence)
+     {
+@@ -168,7 +181,24 @@ void TachSensor::handleResponse(const boost::system::error_code& err,
+         itemIface->set_property("Present", !missing);
+     }
+ 
+-    if (!missing)
++    if (monitor)
++    {
++        failed  = monitor->isPresent();
++        if (failed) 
++        {
++            markFunctional(false);
++            pollTime = sensorFailedPollTimeMs;
++        }
++
++        if (presence) //if presence checks are happening, then there's an invetory item to update
++            itemIface->set_property("Functional", !failed);
++
++        lg2::error("TachSensor '{NAME}' marked as Functional: '{FAILED}'", "NAME", name, "FAILED",
++                   !failed);
++
++    }
++
++    if (!failed)
+     {
+         if (!err)
+         {
+@@ -192,14 +222,30 @@ void TachSensor::handleResponse(const boost::system::error_code& err,
+             pollTime = sensorFailedPollTimeMs;
+         }
+     }
++    else   
++        updateValue(0); //writing a '0' instead of leaving the value as NaN works around a phosphor-pid-control issue with it marking
++                        //fans as 'failed' if NaN is set and immediately going to failsafe speeds w/o looking
++                        //at redundancy rules first TODO: fix how swampd handles 'NaN' values for fans
+ 
+     restartRead(pollTime);
+ }
+ 
+ void TachSensor::checkThresholds()
+ {
++    
+     bool status = thresholds::checkThresholds(this);
+ 
++    if (presence->isPresent() && monitor)
++    {
++        bool failureDetected = monitor->isPresent();
++        
++        if (failureDetected)
++        {
++            status = false; 
++            lg2::error("failbit seen for fan_tach '{NAME}', status=false", "NAME", name);
++        }
++    }
++
+     if ((redundancy != nullptr) && *redundancy)
+     {
+         (*redundancy)
+diff --git a/src/fan/TachSensor.hpp b/src/fan/TachSensor.hpp
+index 6e22f76..d5b8b66 100644
+--- a/src/fan/TachSensor.hpp
++++ b/src/fan/TachSensor.hpp
+@@ -68,6 +68,7 @@ class TachSensor :
+                sdbusplus::asio::object_server& objectServer,
+                std::shared_ptr<sdbusplus::asio::connection>& conn,
+                std::shared_ptr<PresenceGpio>& presence,
++               std::shared_ptr<PresenceGpio>& monitor,
+                std::optional<RedundancySensor>* redundancy,
+                boost::asio::io_context& io, const std::string& fanName,
+                std::vector<thresholds::Threshold>&& thresholds,
+@@ -85,6 +86,7 @@ class TachSensor :
+     sdbusplus::asio::object_server& objServer;
+     std::optional<RedundancySensor>* redundancy;
+     std::shared_ptr<PresenceGpio> presence;
++    std::shared_ptr<PresenceGpio> monitor;
+     std::shared_ptr<sdbusplus::asio::dbus_interface> itemIface;
+     std::shared_ptr<sdbusplus::asio::dbus_interface> itemAssoc;
+     boost::asio::random_access_file inputDev;

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch
@@ -337,7 +337,7 @@ index c8a3c40..258d9e7 100644
 +
 +    }
 +
-+    if (!failed)
++    if (!missing && !failed)
      {
          if (!err)
          {

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch
@@ -6,6 +6,7 @@ Subject: [PATCH] now supports gpio based fail bit monitoring as well as
  'not present' sensors as 'failed' and goes to failsale speed w/o checking
  redundancy rules or fan status on dbus first
 
+Upstream-Status: Pending
 ---
  src/fan/FanMain.cpp    | 155 ++++++++++++++++++++++++++++++++++++-----
  src/fan/TachSensor.cpp |  48 ++++++++++++-

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,8 +1,9 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-support-for-TMP1075-tempsensors.patch \
-            file://0001-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch \
-            "
+SRC_URI += "file://0001-support-for-TMP1075-tempsensors.patch"
+
 SRC_URI += "file://0002-FanMain-geared-up-for-only-HPEFan-support-for-now.patch"
 SRC_URI += "file://0003-IntelCPU-now-has-a-deltaTempFilter-for-reporting-tem.patch"
+
+SRC_URI += "file://0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch"
 

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
-SRC_URI += "file://0001-support-for-TMP1075-tempsensors.patch"
+SRC_URI += "file://0001-support-for-TMP1075-tempsensors.patch \
+            file://0001-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch \
+            "
 SRC_URI += "file://0002-FanMain-geared-up-for-only-HPEFan-support-for-now.patch"
 SRC_URI += "file://0003-IntelCPU-now-has-a-deltaTempFilter-for-reporting-tem.patch"
 

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,9 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://0001-support-for-TMP1075-tempsensors.patch"
-
 SRC_URI += "file://0002-FanMain-geared-up-for-only-HPEFan-support-for-now.patch"
 SRC_URI += "file://0003-IntelCPU-now-has-a-deltaTempFilter-for-reporting-tem.patch"
-
 SRC_URI += "file://0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch"
 


### PR DESCRIPTION
Now with sane fan speeds requested through PID algorithms!

Fan Presence and Fail Fail status is now pulled in from GPIO reads in the FanSensor daemon. 

At the moment, a bug seems to exist where pre-existing calls to functions like MarkAsPresent() don't appear to be updating the expected dbus property on the sensor/fan_tach records.

We know the status checks are working because the values are being updated in the Inventory/fan_tach records 