### PR TITLE
now includes tachless-specific handling for fan_tach value display

### DIFF
--- a/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
+++ b/meta-hpe/recipes-phosphor/configuration/entity-manager/dl340g12.json
@@ -380,6 +380,7 @@
       "Name": "Fan 1",
       "Type": "HPEFan",
       "Index": 1,
+      "MaxReading": 16500,
       "Connector": {
         "_comment1": "on the Dl340, fans reads start from 'hwmon/pwm2' so start fan 1 numbering from pwm=1, and index=1 instead of the usual 0-based",
         "Name": "Fan Conn 1",
@@ -401,6 +402,7 @@
       "Name": "Fan 2",
       "Type": "HPEFan",
       "Index": 2,
+      "MaxReading": 16500,
       "Connector": {
         "Name": "Fan Conn 2",
         "Pwm": 2,
@@ -421,6 +423,7 @@
       "Name": "Fan 3",
       "Type": "HPEFan",
       "Index": 3,
+      "MaxReading": 16500,
       "Connector": {
         "Name": "Fan Conn 3",
         "Pwm": 3,
@@ -441,6 +444,7 @@
       "Name": "Fan 4",
       "Type": "HPEFan",
       "Index": 4,
+      "MaxReading": 16500,
       "Connector": {
         "Name": "Fan Conn 4",
         "Pwm": 4,
@@ -461,6 +465,7 @@
       "Name": "Fan 5",
       "Type": "HPEFan",
       "Index": 5,
+      "MaxReading": 16500,
       "Connector": {
         "Name": "Fan Conn 5",
         "Pwm": 5,
@@ -481,6 +486,7 @@
       "Name": "Fan 6",
       "Type": "HPEFan",
       "Index": 6,
+      "MaxReading": 16500,
       "Connector": {
         "Name": "Fan Conn 6",
         "Pwm": 6,

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0005-added-tachless-specific-handling-for-how-to-display-.patch
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0005-added-tachless-specific-handling-for-how-to-display-.patch
@@ -4,6 +4,7 @@ Date: Mon, 14 Jul 2025 18:42:34 -0500
 Subject: [PATCH] added tachless-specific handling for how to display
  (estimated) 'fan_tach' info
 
+Upstream-Status: Pending
 ---
  src/fan/FanMain.cpp    | 13 +++++++++++--
  src/fan/TachSensor.cpp | 15 +++++++++++++--

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0005-added-tachless-specific-handling-for-how-to-display-.patch
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors/0005-added-tachless-specific-handling-for-how-to-display-.patch
@@ -1,0 +1,102 @@
+From 79d633bb2c217ccbc4ee917c675288b57fa37bf8 Mon Sep 17 00:00:00 2001
+From: Chris Sides <Christopher.Sides@hpe.com>
+Date: Mon, 14 Jul 2025 18:42:34 -0500
+Subject: [PATCH] added tachless-specific handling for how to display
+ (estimated) 'fan_tach' info
+
+---
+ src/fan/FanMain.cpp    | 13 +++++++++++--
+ src/fan/TachSensor.cpp | 15 +++++++++++++--
+ src/fan/TachSensor.hpp |  2 ++
+ 3 files changed, 26 insertions(+), 4 deletions(-)
+
+diff --git a/src/fan/FanMain.cpp b/src/fan/FanMain.cpp
+index 4cd5a61..df3a1df 100644
+--- a/src/fan/FanMain.cpp
++++ b/src/fan/FanMain.cpp
+@@ -739,15 +739,24 @@ void createSensors(
+ 
+             enableFanInput(fanOutputPath);
+ 
++            bool isTachlessFan= false;
+             auto fanInputPath = getFanInputPath(fanOutputPath);
+ 
++            if (fanInputPath == fanOutputPath)
++            {
++                // no tachometer, so we are tachless fan
++                isTachlessFan = true;
++            }
++
++            
++
+             auto& tachSensor = tachSensors[sensorName];
+             tachSensor = nullptr;
+             tachSensor = std::make_shared<TachSensor>(
+                 fanInputPath.string(), baseType, objectServer, dbusConnection,
+                 presenceGpio, monitorGpio, redundancy, io, sensorName,
+-                std::move(sensorThresholds), *interfacePath, limits, powerState,
+-                led);
++                std::move(sensorThresholds), *interfacePath, limits, isTachlessFan, 
++                powerState, led);
+             tachSensor->setupRead();
+ 
+             if (!pwmPath.empty() && std::filesystem::exists(pwmPath) &&
+diff --git a/src/fan/TachSensor.cpp b/src/fan/TachSensor.cpp
+index 258d9e7..8f65a96 100644
+--- a/src/fan/TachSensor.cpp
++++ b/src/fan/TachSensor.cpp
+@@ -53,13 +53,16 @@ TachSensor::TachSensor(
+     const std::string& fanName,
+     std::vector<thresholds::Threshold>&& thresholdsIn,
+     const std::string& sensorConfiguration,
+-    const std::pair<double, double>& limits, const PowerState& powerState,
++    const std::pair<double, double>& limits, 
++    const bool& isTachless,
++    const PowerState& powerState,
+     const std::optional<std::string>& ledIn) :
+     Sensor(escapeName(fanName), std::move(thresholdsIn), sensorConfiguration,
+            objectType, false, false, limits.second, limits.first, conn,
+            powerState),
+     objServer(objectServer), redundancy(redundancy), presence(presenceGpio),
+     monitor(monitorGpio),
++    isTachlessFan(isTachless),
+     inputDev(io, path, boost::asio::random_access_file::read_only),
+     waitTimer(io), path(path), led(ledIn)
+ {
+@@ -213,7 +216,15 @@ void TachSensor::handleResponse(const boost::system::error_code& err,
+             }
+             else
+             {
+-                updateValue(nvalue);
++                if (isTachlessFan) //then we're reading a PWM duty cycle as input. Calculate a displayable RPM from any MaxReading defined for a fan
++                {
++                    auto calcFract = (double)nvalue / 255;
++                    auto dutyToRPMCalc = static_cast<int>(calcFract * this->maxValue);
++
++                    updateValue(dutyToRPMCalc);
++                }
++                else
++                    updateValue(nvalue);
+             }
+         }
+         else
+diff --git a/src/fan/TachSensor.hpp b/src/fan/TachSensor.hpp
+index d5b8b66..095b159 100644
+--- a/src/fan/TachSensor.hpp
++++ b/src/fan/TachSensor.hpp
+@@ -74,6 +74,7 @@ class TachSensor :
+                std::vector<thresholds::Threshold>&& thresholds,
+                const std::string& sensorConfiguration,
+                const std::pair<double, double>& limits,
++               const bool& isTachless,
+                const PowerState& powerState,
+                const std::optional<std::string>& led);
+     ~TachSensor() override;
+@@ -89,6 +90,7 @@ class TachSensor :
+     std::shared_ptr<PresenceGpio> monitor;
+     std::shared_ptr<sdbusplus::asio::dbus_interface> itemIface;
+     std::shared_ptr<sdbusplus::asio::dbus_interface> itemAssoc;
++    bool isTachlessFan = false;
+     boost::asio::random_access_file inputDev;
+     boost::asio::steady_timer waitTimer;
+     std::string path;

--- a/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
+++ b/meta-hpe/recipes-phosphor/sensors/dbus-sensors_%.bbappend
@@ -1,9 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://0001-support-for-TMP1075-tempsensors.patch"
-
 SRC_URI += "file://0002-FanMain-geared-up-for-only-HPEFan-support-for-now.patch"
 SRC_URI += "file://0003-IntelCPU-now-has-a-deltaTempFilter-for-reporting-tem.patch"
-
 SRC_URI += "file://0004-now-supports-gpio-based-fail-bit-monitoring-as-well-.patch"
+SRC_URI += "file://0005-added-tachless-specific-handling-for-how-to-display-.patch"
 


### PR DESCRIPTION
Gets the fan_tach sensors records reporting something that looks sane

<img width="1199" height="748" alt="image" src="https://github.com/user-attachments/assets/2629e5e5-aaae-490c-8b5a-596d3fef4f20" />

(note: the abovescreenshot was taken on a system using the 'default' MaxReading = 25,000)
