### PR TITLE
Enable cooker console interaction for newer OpenBMC code.

### DIFF
--- a/meta-hpe/meta-gsc/conf/machine/include/gsc.inc
+++ b/meta-hpe/meta-gsc/conf/machine/include/gsc.inc
@@ -58,3 +58,6 @@ PREFERRED_PROVIDER_virtual/obmc-chassis-mgmt = "packagegroup-hpe-apps"
 PREFERRED_PROVIDER_virtual/obmc-fan-mgmt = "packagegroup-hpe-apps"
 PREFERRED_PROVIDER_virtual/obmc-flash-mgmt = "packagegroup-hpe-apps"
 PREFERRED_PROVIDER_virtual/obmc-system-mgmt = "packagegroup-hpe-apps"
++
++# Enable serial console on ttyS0
++SERIAL_CONSOLES = "115200;ttyS0"


### PR DESCRIPTION
The OpenBMC Change:
In bitbake.conf:
SERIAL_CONSOLES ??= ""
The newer Yocto/OpenBMC versions changed SERIAL_CONSOLES to default to empty instead of having an automatic ttyS0/ttyS4 default. This broke the serial console ("cooker" connection"). 

Old behavior: Systems would automatically enable getty on common serial ports
New behavior: SERIAL_CONSOLES defaults to empty, so no serial getty services are started unless explicitly configured.

This is fixed by Adding:
SERIAL_CONSOLES = "115200;ttyS0"
to gsc.inc
This explicitly tells systemd to start serial-getty@ttyS0.service at 115200 baud, restoring the cooker connection.