### PR TITLE
Pick up changes for SBMC-5061 in chif and proliant-support.

### DIFF
--- a/meta-hpe/recipes-hpe/chif/chif_git.bb
+++ b/meta-hpe/recipes-hpe/chif/chif_git.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "HPE CHIF service to support BIOS"
 
 BRANCH = "main"
 SRC_URI = "git://github.com/HewlettPackard/openbmc-chif-svc.git;branch=${BRANCH};protocol=https"
-SRCREV = "0889d236545f8b1b3b53d25bec0b23cce16e0a2d"
+SRCREV = "75f98cc221bd17a9ed00cd8b404ccccd2183934a"
 
 PV = "0.1+git${SRCPV}"
 

--- a/meta-hpe/recipes-hpe/proliant-support/proliant-support.bb
+++ b/meta-hpe/recipes-hpe/proliant-support/proliant-support.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Recipes to support HPE ProLiant server hardware and firmware"
 
 BRANCH = "main"
 SRC_URI = "git://github.com/HewlettPackard/openbmc-proliant-support.git;branch=${BRANCH};protocol=https"
-SRCREV = "b5d73359461cac84d2dd69f5ea60e71a25e33eb6"
+SRCREV = "be41cc5df6f7dfe5a14fbf375476f81b0e42a116"
 
 PV = "0.1+git${SRCPV}"
 


### PR DESCRIPTION
Update hash pointers to tot chif and proliant-support.  These two changes are lock-stepped and need to be picked up at the same time.  Supports using only the APML platdef data for the current platform instead of loading the complete APML bundle for multiple platforms.