### PR TITLE
Update linux-gsc_git.bb

### DIFF
--- a/meta-hpe/meta-gsc/recipes-kernel/linux/linux-gsc_git.bb
+++ b/meta-hpe/meta-gsc/recipes-kernel/linux/linux-gsc_git.bb
@@ -1,7 +1,7 @@
 inherit kernel
 require recipes-kernel/linux/linux-yocto.inc
 
-SRCREV = "0c81397fb7a5ba6f54921c92ad1eae3b2d0b868f"
+SRCREV = "78b19f76bc4cc67d15e63d2e4cd2764efa56c572"
 KBRANCH = "gsc-linux-6.12.62"
 SRC_URI = "git://github.com/HewlettPackard/gsc-linux.git;protocol=https;branch=${KBRANCH};depth=1 \
            file://gsc_defconfig \


### PR DESCRIPTION
Pick up tot gsc-linux-6.12.62 fix for i2c driver buffer overrun.