### PR TITLE
chore: update openbmc

### DIFF
--- a/meta-hpe/recipes-hpe/gxp-dbus-sensors/gxp-dbus-sensors.bb
+++ b/meta-hpe/recipes-hpe/gxp-dbus-sensors/gxp-dbus-sensors.bb
@@ -16,6 +16,7 @@ SRC_URI += "file://0001-fix-update-io_service-to-io_context.patch"
 SRC_URI += "file://0002-fix-update-io.post-to-boost-asio-post.patch"
 SRC_URI += "file://0003-don-t-build-or-install-the-gxp-fan-sensors-daemon.patch"
 SRC_URI += "file://0004-remove-sdbusplus-project-dependency.patch"
+SRC_URI += "file://0005-fix-sdbusplus-api-compat.patch"
 
 PV = "1.0+git"
 

--- a/meta-hpe/recipes-hpe/gxp-dbus-sensors/gxp-dbus-sensors/0005-fix-sdbusplus-api-compat.patch
+++ b/meta-hpe/recipes-hpe/gxp-dbus-sensors/gxp-dbus-sensors/0005-fix-sdbusplus-api-compat.patch
@@ -1,0 +1,99 @@
+From 9a9bcf8f84c2d4e8a2b522d13bcbf4a2d8350001 Mon Sep 17 00:00:00 2001
+From: automated <automated@example.com>
+Date: Thu, 25 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Fix sdbusplus API compatibility
+
+Update deprecated/removed sdbusplus type names to current aliases.
+
+Upstream-Status: Inappropriate [oe-specific compatibility]
+---
+ include/Utils.hpp     | 2 +-
+ src/GxpTempSensor.cpp | 6 +++---
+ src/Utils.cpp         | 8 ++++----
+ 3 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/include/Utils.hpp b/include/Utils.hpp
+index 0123b33..dcc8fdf 100644
+--- a/include/Utils.hpp
++++ b/include/Utils.hpp
+@@ -51,7 +51,7 @@ using SensorBaseConfigMap =
+ using SensorBaseConfiguration = std::pair<std::string, SensorBaseConfigMap>;
+ using SensorData = boost::container::flat_map<std::string, SensorBaseConfigMap>;
+ using ManagedObjectType =
+-    boost::container::flat_map<sdbusplus::message::object_path, SensorData>;
++    boost::container::flat_map<sdbusplus::object_path, SensorData>;
+ 
+ using GetSubTreeType = std::vector<
+     std::pair<std::string,
+diff --git a/src/GxpTempSensor.cpp b/src/GxpTempSensor.cpp
+index 90d09cd..e7a5293 100644
+--- a/src/GxpTempSensor.cpp
++++ b/src/GxpTempSensor.cpp
+@@ -225,7 +225,7 @@ void createSensor(
+                 const char* sensorType = nullptr;
+                 const SensorBaseConfiguration* baseConfiguration = nullptr;
+                 const SensorBaseConfigMap* baseConfigMap = nullptr;
+-                for (const std::pair<sdbusplus::message::object_path, SensorData>& sensorConfiguration : sensorConfigurations)
++                for (const std::pair<sdbusplus::object_path, SensorData>& sensorConfiguration : sensorConfigurations)
+                 {
+                     sensorData = &(sensorConfiguration.second);
+                     for (const char* type : sensorTypes)
+@@ -302,7 +302,7 @@ int main()
+     sdbusplus::asio::object_server objectServer(dbusConnection);
+     objectServer.add_manager("/xyz/openbmc_project/sensors");
+     std::shared_ptr<GxpTempSensor> sensor = nullptr;
+-    std::vector<std::unique_ptr<sdbusplus::bus::match::match>> matches;
++    std::vector<std::unique_ptr<sdbusplus::bus::match_t>> matches;
+ 
+     boost::asio::post(io, [&]()
+     {
+@@ -347,8 +347,8 @@ int main()
+ 
+     for (const char* type : sensorTypes)
+     {
+-        auto match = std::make_unique<sdbusplus::bus::match::match>(
+-            static_cast<sdbusplus::bus::bus&>(*dbusConnection),
++        auto match = std::make_unique<sdbusplus::bus::match_t>(
++            static_cast<sdbusplus::bus_t&>(*dbusConnection),
+             "type='signal',member='PropertiesChanged',path_namespace='" +
+             std::string(inventoryPath) + "',arg0namespace='" + type + "'",
+             eventHandler);
+diff --git a/src/Utils.cpp b/src/Utils.cpp
+index f11a520..81c4ea7 100644
+--- a/src/Utils.cpp
++++ b/src/Utils.cpp
+@@ -37,8 +37,8 @@ namespace fs = std::filesystem;
+ static bool powerStatusOn = false;
+ static bool biosHasPost = false;
+ 
+-static std::unique_ptr<sdbusplus::bus::match::match> powerMatch = nullptr;
+-static std::unique_ptr<sdbusplus::bus::match::match> postMatch = nullptr;
++static std::unique_ptr<sdbusplus::bus::match_t> powerMatch = nullptr;
++static std::unique_ptr<sdbusplus::bus::match_t> postMatch = nullptr;
+ 
+ bool getSensorConfiguration(
+     const std::string& type,
+@@ -147,8 +147,8 @@ void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn)
+         return;
+     }
+ 
+-    powerMatch = std::make_unique<sdbusplus::bus::match::match>(
+-        static_cast<sdbusplus::bus::bus&>(*conn),
++    powerMatch = std::make_unique<sdbusplus::bus::match_t>(
++        static_cast<sdbusplus::bus_t&>(*conn),
+         "type='signal',interface='" + std::string(properties::interface) +
+             "',path='" + std::string(power::path) + "',arg0='" +
+             std::string(power::interface) + "'",
+@@ -185,8 +185,8 @@ void setupPowerMatch(const std::shared_ptr<sdbusplus::asio::connection>& conn)
+             }
+         });
+ 
+-    postMatch = std::make_unique<sdbusplus::bus::match::match>(
+-        static_cast<sdbusplus::bus::bus&>(*conn),
++    postMatch = std::make_unique<sdbusplus::bus::match_t>(
++        static_cast<sdbusplus::bus_t&>(*conn),
+         "type='signal',interface='" + std::string(properties::interface) +
+             "',path='" + std::string(post::path) + "',arg0='" +
+             std::string(post::interface) + "'",
+-- 
+2.34.1

--- a/meta-hpe/recipes-hpe/proliant-support/files/0001-fix-sdbusplus-api-compat.patch
+++ b/meta-hpe/recipes-hpe/proliant-support/files/0001-fix-sdbusplus-api-compat.patch
@@ -1,0 +1,26 @@
+From 6af3e4f0f0a995a5d7a3a4a53187b12345670001 Mon Sep 17 00:00:00 2001
+From: automated <automated@example.com>
+Date: Thu, 25 Jun 2026 00:00:00 +0000
+Subject: [PATCH] Fix sdbusplus API compatibility
+
+Update deprecated/removed sdbusplus type names to current aliases.
+
+Upstream-Status: Inappropriate [oe-specific compatibility]
+---
+ src/host_state_monitor.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/host_state_monitor.cpp b/src/host_state_monitor.cpp
+index 39f4db7..f76ecf0 100644
+--- a/src/host_state_monitor.cpp
++++ b/src/host_state_monitor.cpp
+@@ -21,2 +21,2 @@ private:
+-    sdbusplus::bus::bus bus;
+-    std::unique_ptr<sdbusplus::bus::match::match> match;
++    sdbusplus::bus_t bus;
++    std::unique_ptr<sdbusplus::bus::match_t> match;
+@@ -47 +47 @@ int initialize() {
+-            match = std::make_unique<sdbusplus::bus::match::match>(
++            match = std::make_unique<sdbusplus::bus::match_t>(
+-- 
+2.34.1

--- a/meta-hpe/recipes-hpe/proliant-support/proliant-support.bb
+++ b/meta-hpe/recipes-hpe/proliant-support/proliant-support.bb
@@ -3,6 +3,7 @@ DESCRIPTION = "Recipes to support HPE ProLiant server hardware and firmware"
 
 BRANCH = "main"
 SRC_URI = "git://github.com/HewlettPackard/openbmc-proliant-support.git;branch=${BRANCH};protocol=https"
+SRC_URI += "file://0001-fix-sdbusplus-api-compat.patch"
 SRCREV = "be41cc5df6f7dfe5a14fbf375476f81b0e42a116"
 
 PV = "0.1+git${SRCPV}"

--- a/meta-hpe/recipes-phosphor/configuration/entity-manager/0001-Entity-Manager-support-for-cooling-cooled_by-associa.patch
+++ b/meta-hpe/recipes-phosphor/configuration/entity-manager/0001-Entity-Manager-support-for-cooling-cooled_by-associa.patch
@@ -1,4 +1,4 @@
-From 2158303e2087ef5824b9cd770175772eaabbf960 Mon Sep 17 00:00:00 2001
+From 778f3ef34908e7fed1745e0970299188a7081e8e Mon Sep 17 00:00:00 2001
 From: Chris Sides <Christopher.Sides@hpe.com>
 Date: Mon, 11 Aug 2025 16:10:55 -0500
 Subject: [PATCH] Entity-Manager support for cooling/cooled_by associations
@@ -18,13 +18,13 @@ Upstream-Status: Pending
  1 file changed, 18 insertions(+), 1 deletion(-)
 
 diff --git a/src/entity_manager/topology.cpp b/src/entity_manager/topology.cpp
-index bac865492..c51cbc143 100644
+index cc87ba5..3194026 100644
 --- a/src/entity_manager/topology.cpp
 +++ b/src/entity_manager/topology.cpp
-@@ -15,6 +15,11 @@ const AssocName assocPowering =
+@@ -17,6 +17,11 @@ const AssocName assocPowering =
                {"Board", "Chassis", "PowerSupply"});
  const AssocName assocPoweredBy = assocPowering.getReverse();
-
+ 
 +const AssocName assocCooling =
 +    AssocName("cooling", "cooled_by", {"Chassis", "Board", "Fan"},
 +              {"Board", "Chassis", "Fan"});
@@ -32,17 +32,17 @@ index bac865492..c51cbc143 100644
 +
  const AssocName assocProbing = AssocName("probing", "probed_by", {}, {});
  const AssocName assocProbedBy = assocProbing.getReverse();
-
-@@ -23,6 +28,8 @@ const std::vector<AssocName> supportedAssocs = {
+ 
+@@ -25,6 +30,8 @@ const std::vector<AssocName> supportedAssocs = {
      assocContainedBy,
      assocPowering,
      assocPoweredBy,
 +    assocCooling,
 +    assocCooledBy,
  };
-
+ 
  AssocName::AssocName(const std::string& name, const std::string& reverse,
-@@ -84,6 +91,9 @@ void Topology::addBoard(const std::string& path, const std::string& boardType,
+@@ -87,6 +94,9 @@ void Topology::addBoard(const sdbusplus::object_path& path,
          // in the
          // powered_by association
          addPort(exposesType, path, assocPoweredBy);
@@ -52,7 +52,7 @@ index bac865492..c51cbc143 100644
      }
      else
      {
-@@ -141,6 +151,12 @@ void Topology::addDownstreamPort(const Path& path,
+@@ -144,6 +154,12 @@ void Topology::addDownstreamPort(const sdbusplus::object_path& path,
      {
          addPort(connectsTo, path, assocPowering);
      }
@@ -63,10 +63,10 @@ index bac865492..c51cbc143 100644
 +        addPort(connectsTo, path, assocCooling);
 +    }
  }
-
- void Topology::addPort(const PortType& port, const Path& path,
-@@ -235,7 +251,8 @@ void Topology::fillAssocForPortId(
-
+ 
+ void Topology::addPort(const PortType& port, const sdbusplus::object_path& path,
+@@ -238,7 +254,8 @@ void Topology::fillAssocForPortId(
+ 
      // quirk: legacy code did not associate from both sides
      // TODO(alexander): revisit this
 -    if (assocName == assocContaining || assocName == assocPoweredBy)
@@ -75,5 +75,3 @@ index bac865492..c51cbc143 100644
      {
          return;
      }
---
-2.53.0

--- a/meta-hpe/recipes-x86/chassis/x86-power-control/0001-Fix-x86-power-control-issues.patch
+++ b/meta-hpe/recipes-x86/chassis/x86-power-control/0001-Fix-x86-power-control-issues.patch
@@ -1,4 +1,4 @@
-From e05ac448fd640d914ebe89b268eecac59046b806 Mon Sep 17 00:00:00 2001
+From 61fb573b671bed382edc15fab7c529c9a2437a1c Mon Sep 17 00:00:00 2001
 From: Nick Hawkins <nick.hawkins@hpe.com>
 Date: Mon, 22 Apr 2024 09:34:27 -0500
 Subject: [PATCH] Fix x86-power-control issues
@@ -16,7 +16,7 @@ Signed-off-by: Nick Hawkins <nick.hawkins@hpe.com>
  2 files changed, 21 insertions(+), 3 deletions(-)
 
 diff --git a/config/power-config-host0.json b/config/power-config-host0.json
-index 74e96c9..0b7eb8b 100644
+index 88b506e..39766c2 100644
 --- a/config/power-config-host0.json
 +++ b/config/power-config-host0.json
 @@ -40,7 +40,7 @@
@@ -38,22 +38,22 @@ index 74e96c9..0b7eb8b 100644
          {
              "Name": "SioOnControl",
 diff --git a/src/power_control.cpp b/src/power_control.cpp
-index bba7088..0b4995e 100644
+index b58cd59..11682c9 100644
 --- a/src/power_control.cpp
 +++ b/src/power_control.cpp
-@@ -197,6 +197,10 @@ static gpiod::line postCompleteLine;
- static boost::asio::posix::stream_descriptor postCompleteEvent(io);
+@@ -208,6 +208,10 @@ static gpiod::line PlatformResetLine;
+ static boost::asio::posix::stream_descriptor platformResetEvent(io);
  static gpiod::line nmiOutLine;
  static gpiod::line slotPowerLine;
 +static gpiod::line fwValidatePassLine;
 +std::string fwValidatePasslineName = "FW_VALIDATION_PASSED";
 +static gpiod::line pS5tS5SSLine;
 +std::string pS5tS5SSLineName = "PS5_TS5_SS_CMP";
-
+ 
  static constexpr uint8_t beepPowerFail = 8;
-
-@@ -1177,7 +1181,15 @@ static bool requestGPIOEvents(
-
+ 
+@@ -1141,7 +1145,15 @@ static bool requestGPIOEvents(
+ 
      try
      {
 -        gpioLine.request({appName, gpiod::line_request::EVENT_BOTH_EDGES, {}});
@@ -69,7 +69,7 @@ index bba7088..0b4995e 100644
      }
      catch (const std::exception& e)
      {
-@@ -1831,10 +1843,16 @@ static void powerStateOff(const Event event)
+@@ -1801,10 +1813,16 @@ static void powerStateOff(const Event event)
              setPowerState(PowerState::waitForPowerOK);
              break;
          case Event::sioPowerGoodAssert:


### PR DESCRIPTION
Update OpenBMC to master TOT (needed now for bitbake update to use CDN for Rust crate fetches).

Update gxp-dbus-sensors and proliant-support to build after changes to the sdbusplus client API.

Refresh meta-hpe patches that apply with fuzz after the OBMC update.